### PR TITLE
Fix build

### DIFF
--- a/src/injdll/injdll.vcxproj
+++ b/src/injdll/injdll.vcxproj
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<EnableStdModules>false</EnableStdModules>
+	</PropertyGroup>
   <!-- ProjectConfigurations -->
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">

--- a/src/injdrv/injdrv.vcxproj
+++ b/src/injdrv/injdrv.vcxproj
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- ProjectConfigurations -->
+	<PropertyGroup>
+		<EnableStdModules>false</EnableStdModules>
+	</PropertyGroup>
+	<!-- ProjectConfigurations -->
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>

--- a/src/injldr/injldr.vcxproj
+++ b/src/injldr/injldr.vcxproj
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- ProjectConfigurations -->
+	<PropertyGroup>
+		<EnableStdModules>false</EnableStdModules>
+	</PropertyGroup>
+
+	<!-- ProjectConfigurations -->
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>

--- a/src/injlib/injlib.vcxproj
+++ b/src/injlib/injlib.vcxproj
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- ProjectConfigurations -->
+	<PropertyGroup>
+		<EnableStdModules>false</EnableStdModules>
+	</PropertyGroup>
+	<!-- ProjectConfigurations -->
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>


### PR DESCRIPTION
Fix build based on
https://stackoverflow.com/questions/76055294/relative-output-directory-for-object-file-name
for VS 2022 Community 2022 17.7.0